### PR TITLE
Updated for a more goish style

### DIFF
--- a/go/example07.go
+++ b/go/example07.go
@@ -51,9 +51,9 @@ func (rl *RandomLine) Reset() {
 	rl.increment = (rl.end - rl.curVal) / rl.dur
 }
 
-// The receiver has to be a pointer because the GetValue function
+// The receiver has to be a pointer because the Value function
 // changes the value of the receiver members
-func (rl *RandomLine) GetValue() csnd6.MYFLT {
+func (rl *RandomLine) Value() csnd6.MYFLT {
 	rl.dur -= 1
 	if rl.dur < 0 {
 		rl.Reset()
@@ -95,15 +95,15 @@ func main() {
 	amp := NewRandomLine(.4, .2)   // create RandomLine for use with Amplitude
 	freq := NewRandomLine(400, 80) // create RandomLine for use with Frequency
 
-	c.SetControlChannel("amp", amp.GetValue())   // Initialize channel value before running Csound
-	c.SetControlChannel("freq", freq.GetValue()) // Initialize channel value before running Csound
+	c.SetControlChannel("amp", amp.Value())   // Initialize channel value before running Csound
+	c.SetControlChannel("freq", freq.Value()) // Initialize channel value before running Csound
 
 	// The following is our main performance loop. We will perform one block of sound at a time
 	// and continue to do so while it returns 0, which signifies to keep processing.
 
 	for c.PerformKsmps() == 0 {
-		c.SetControlChannel("amp", amp.GetValue())   // update channel value
-		c.SetControlChannel("freq", freq.GetValue()) // update channel value
+		c.SetControlChannel("amp", amp.Value())   // update channel value
+		c.SetControlChannel("freq", freq.Value()) // update channel value
 	}
 	c.Stop()
 }

--- a/go/example08.go
+++ b/go/example08.go
@@ -3,11 +3,11 @@
 // from the original python example by Steven Yi <stevenyi@gmail.com>
 //
 // This example builds on Example 7 by replacing the calls to SetChannel
-// with using GetChannelPtr. In the Csound API, using SetChannel and GetChannel
+// with using ChannelPtr. In the Csound API, using SetChannel and Channel
 // is great for quick work, but ultimately it is slower than pre-fetching the
-// actual channel pointer. This is because Set/GetChannel operates by doing a
+// actual channel pointer. This is because SetChannel/Channel operates by doing a
 // lookup of the Channel Pointer, then setting or getting the value. This
-// happens on each call. The alternative is to use GetChannelPtr, which fetches
+// happens on each call. The alternative is to use ChannelPtr, which fetches
 // the Channel Pointer and lets you directly set and get the value on the pointer.
 //
 // In C/C++/Objective-C, one can directly use MYFLT* to get/set values. However,
@@ -17,7 +17,7 @@
 // The []csnd6.MYFLT in turn is used in the classical Go way for setting
 // and getting values.
 //
-// The code below shows how to use the []csnd6.MYFLT in conjunction with GetChannelPtr
+// The code below shows how to use the []csnd6.MYFLT in conjunction with ChannelPtr
 // to have a more optimized channel setting system.
 
 package main
@@ -48,9 +48,9 @@ func (rl *RandomLine) Reset() {
 	rl.increment = (rl.end - rl.curVal) / rl.dur
 }
 
-// The receiver has to be a pointer because the GetValue function
+// The receiver has to be a pointer because the Value function
 // changes the value of the receiver members
-func (rl *RandomLine) GetValue() csnd6.MYFLT {
+func (rl *RandomLine) Value() csnd6.MYFLT {
 	rl.dur -= 1
 	if rl.dur < 0 {
 		rl.Reset()
@@ -91,12 +91,12 @@ func main() {
 
 	// the following calls store the Channel Pointer retreived from Csound into the
 	// returned []csnd6.MYFLT slices
-	ampChannel, err := c.GetChannelPtr("amp",
+	ampChannel, err := c.ChannelPtr("amp",
 		csnd6.CSOUND_CONTROL_CHANNEL|csnd6.CSOUND_INPUT_CHANNEL)
 	if err != nil {
 		panic(err)
 	}
-	freqChannel, err := c.GetChannelPtr("freq",
+	freqChannel, err := c.ChannelPtr("freq",
 		csnd6.CSOUND_CONTROL_CHANNEL|csnd6.CSOUND_INPUT_CHANNEL)
 	if err != nil {
 		panic(err)
@@ -105,12 +105,12 @@ func main() {
 	amp := NewRandomLine(.4, .2)
 	freq := NewRandomLine(400, 80)
 
-	ampChannel[0] = amp.GetValue() // note we are now setting values on the []csnd6.MYFLT slice
-	freqChannel[0] = freq.GetValue()
+	ampChannel[0] = amp.Value() // note we are now setting values on the []csnd6.MYFLT slice
+	freqChannel[0] = freq.Value()
 
 	for c.PerformKsmps() == 0 {
-		ampChannel[0] = amp.GetValue()
-		freqChannel[0] = freq.GetValue()
+		ampChannel[0] = amp.Value()
+		freqChannel[0] = freq.Value()
 	}
 	c.Stop()
 }

--- a/go/example09.go
+++ b/go/example09.go
@@ -37,9 +37,9 @@ func (rl *RandomLine) Reset() {
 	rl.increment = (rl.end - rl.curVal) / rl.dur
 }
 
-// The receiver has to be a pointer because the GetValue function
+// The receiver has to be a pointer because the Value function
 // changes the value of the receiver members
-func (rl *RandomLine) GetValue() csnd6.MYFLT {
+func (rl *RandomLine) Value() csnd6.MYFLT {
 	rl.dur -= 1
 	if rl.dur < 0 {
 		rl.Reset()
@@ -50,7 +50,7 @@ func (rl *RandomLine) GetValue() csnd6.MYFLT {
 }
 
 func createChannel(csound csnd6.CSOUND, channelName string) []csnd6.MYFLT {
-	chn, err := csound.GetChannelPtr(channelName,
+	chn, err := csound.ChannelPtr(channelName,
 		csnd6.CSOUND_CONTROL_CHANNEL|csnd6.CSOUND_INPUT_CHANNEL)
 	if err != nil {
 		panic(err)
@@ -93,12 +93,12 @@ func main() {
 	amp := NewRandomLine(.4, .2)
 	freq := NewRandomLine(400, 80)
 
-	ampChannel[0] = amp.GetValue()
-	freqChannel[0] = freq.GetValue()
+	ampChannel[0] = amp.Value()
+	freqChannel[0] = freq.Value()
 
 	for c.PerformKsmps() == 0 {
-		ampChannel[0] = amp.GetValue()
-		freqChannel[0] = freq.GetValue()
+		ampChannel[0] = amp.Value()
+		freqChannel[0] = freq.Value()
 	}
 	c.Stop()
 }

--- a/go/example10.go
+++ b/go/example10.go
@@ -46,9 +46,9 @@ func (rl *RandomLine) Reset() {
 	rl.increment = (rl.end - rl.curVal) / rl.dur
 }
 
-// The receiver has to be a pointer because the GetValue function
+// The receiver has to be a pointer because the Value function
 // changes the value of the receiver members
-func (rl *RandomLine) GetValue() csnd6.MYFLT {
+func (rl *RandomLine) Value() csnd6.MYFLT {
 	rl.dur -= 1
 	if rl.dur < 0 {
 		rl.Reset()
@@ -59,11 +59,11 @@ func (rl *RandomLine) GetValue() csnd6.MYFLT {
 }
 
 type Updater interface {
-	GetValue() csnd6.MYFLT
+	Value() csnd6.MYFLT
 }
 
 func createChannel(csound csnd6.CSOUND, channelName string) []csnd6.MYFLT {
-	chn, err := csound.GetChannelPtr(channelName,
+	chn, err := csound.ChannelPtr(channelName,
 		csnd6.CSOUND_CONTROL_CHANNEL|csnd6.CSOUND_INPUT_CHANNEL)
 	if err != nil {
 		panic(err)
@@ -85,7 +85,7 @@ func NewChannelUpdater(csound csnd6.CSOUND, channelName string, updater Updater)
 }
 
 func (cu ChannelUpdater) Update() {
-	cu.channel[0] = cu.updater.GetValue()
+	cu.channel[0] = cu.updater.Value()
 }
 
 // Our Orchestra for our project

--- a/go/example13.go
+++ b/go/example13.go
@@ -35,9 +35,9 @@ func (rl *RandomLine) Reset() {
 	rl.increment = (rl.end - rl.curVal) / rl.dur
 }
 
-// The receiver has to be a pointer because the GetValue function
+// The receiver has to be a pointer because the Value function
 // changes the value of the receiver members
-func (rl *RandomLine) GetValue() csnd6.MYFLT {
+func (rl *RandomLine) Value() csnd6.MYFLT {
 	rl.dur -= 1
 	if rl.dur < 0 {
 		rl.Reset()
@@ -48,11 +48,11 @@ func (rl *RandomLine) GetValue() csnd6.MYFLT {
 }
 
 type Updater interface {
-	GetValue() csnd6.MYFLT
+	Value() csnd6.MYFLT
 }
 
 func createChannel(csound csnd6.CSOUND, channelName string) []csnd6.MYFLT {
-	chn, err := csound.GetChannelPtr(channelName,
+	chn, err := csound.ChannelPtr(channelName,
 		csnd6.CSOUND_CONTROL_CHANNEL|csnd6.CSOUND_INPUT_CHANNEL)
 	if err != nil {
 		panic(err)
@@ -74,7 +74,7 @@ func NewChannelUpdater(csound csnd6.CSOUND, channelName string, updater Updater)
 }
 
 func (cu ChannelUpdater) Update() {
-	cu.channel[0] = cu.updater.GetValue()
+	cu.channel[0] = cu.updater.Value()
 }
 
 // Our Orchestra for our project


### PR DESCRIPTION
Getter functions in my bindings of the Csound API are now named without the Get prefix (go recommended coding style). I modified examples 7, 8, 9, 10, and 13 in the go folder to follow this.
