### PR TITLE
Fix: typo and innaccurate description of multiline string as triple-q…

### DIFF
--- a/c/example10.c
+++ b/c/example10.c
@@ -100,7 +100,7 @@ void update_channel(channel_updater* updater) {
 }
     
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example2.c
+++ b/c/example2.c
@@ -13,7 +13,7 @@
 #include <stdio.h>
 #include <csound.h>
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example3.c
+++ b/c/example3.c
@@ -11,7 +11,7 @@
 #include <stdio.h>
 #include <csound.h>
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example4.c
+++ b/c/example4.c
@@ -23,7 +23,7 @@
 // forward declaration of performance function
 uintptr_t performance_function(void* data);
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example5.c
+++ b/c/example5.c
@@ -38,7 +38,7 @@
 #include <time.h>
 
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example6.c
+++ b/c/example6.c
@@ -25,7 +25,7 @@ typedef struct _note {
     int midi_keynum;
 } Note;
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example7.c
+++ b/c/example7.c
@@ -69,7 +69,7 @@ double random_line_tick(random_line* rline) {
     return rline->base + (current_value * rline->range);
 }
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example8.c
+++ b/c/example8.c
@@ -64,7 +64,7 @@ double random_line_tick(random_line* rline) {
     return rline->base + (current_value * rline->range);
 }
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/c/example9.c
+++ b/c/example9.c
@@ -63,7 +63,7 @@ MYFLT* create_channel(CSOUND* csound, char* channel_name) {
     return chn;
 }
 
-/* Defining our Csound ORC code within a triple-quoted, multline String */
+/* Defining our Csound ORC code within a multiline String */
 const char* orc = "sr=44100\n"
   "ksmps=32\n"
   "nchnls=2\n"

--- a/clojure/example10.clj
+++ b/clojure/example10.clj
@@ -72,7 +72,7 @@
       (println "Setting value...")
       (.SetValue chn 0 (update-func)))))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example2.clj
+++ b/clojure/example2.clj
@@ -14,7 +14,7 @@
 ; this line turns off Csound's atexit handler as well as signal handlers
 (csnd6/csoundInitialize (bit-or csnd6/CSOUNDINIT_NO_ATEXIT csnd6/CSOUNDINIT_NO_SIGNAL_HANDLER))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example3.clj
+++ b/clojure/example3.clj
@@ -12,7 +12,7 @@
 ; this line turns off Csound's atexit handler as well as signal handlers
 (csnd6/csoundInitialize (bit-or csnd6/CSOUNDINIT_NO_ATEXIT csnd6/CSOUNDINIT_NO_SIGNAL_HANDLER))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example5.clj
+++ b/clojure/example5.clj
@@ -38,7 +38,7 @@
 ; this line turns off Csound's atexit handler as well as signal handlers
 (csnd6/csoundInitialize (bit-or csnd6/CSOUNDINIT_NO_ATEXIT csnd6/CSOUNDINIT_NO_SIGNAL_HANDLER))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example6.clj
+++ b/clojure/example6.clj
@@ -34,7 +34,7 @@
         mpch (last note)]
    (str "i" (join " " pfields) " " (midi->pch mpch))))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example7.clj
+++ b/clojure/example7.clj
@@ -54,7 +54,7 @@
         (swap! (:curval state) #(+ % @(:increment state))) 
         (+ base (* range c))))))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example8.clj
+++ b/clojure/example8.clj
@@ -54,7 +54,7 @@
         (swap! (:curval state) #(+ % @(:increment state))) 
         (+ base (* range c))))))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/clojure/example9.clj
+++ b/clojure/example9.clj
@@ -54,7 +54,7 @@
     (.GetChannelPtr csound (.GetPtr chn) channel-name ctrl-chan-type)
     chn))
 
-; Defining our Csound ORC code within a triple-quoted, multline String
+; Defining our Csound ORC code within a multiline String
 (def orc "
 sr=44100
 ksmps=32

--- a/go/example02.go
+++ b/go/example02.go
@@ -13,7 +13,7 @@ package main
 
 import "github.com/fggp/go-csnd6"
 
-// Defining our Csound ORC code within a triple-quoted, multline String
+// Defining our Csound ORC code within a multiline String
 var orc string = `
 sr=48000
 ksmps=32

--- a/lua/example2.lua
+++ b/lua/example2.lua
@@ -11,7 +11,7 @@
 
 require "luaCsnd6"
 
--- Defining our Csound ORC code within a triple-quoted, multline String
+-- Defining our Csound ORC code within a multiline String
 orc = [[
 sr=44100
 ksmps=32

--- a/python/CtcsoundAPIExamples.ipynb
+++ b/python/CtcsoundAPIExamples.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "# Defining our Csound ORC code within a triple-quoted, multline String\n",
+    "# Defining our Csound ORC code within a triple-quoted, multiline String\n",
     "orc = \"\"\"\n",
     "sr=44100\n",
     "ksmps=32\n",

--- a/python/CtcsoundAPIExamples.ipynb
+++ b/python/CtcsoundAPIExamples.ipynb
@@ -65,7 +65,7 @@
    },
    "outputs": [],
    "source": [
-    "# Defining our Csound ORC code within a triple-quoted, multiline String\n",
+    "# Defining our Csound ORC code within a multiline String\n",
     "orc = \"\"\"\n",
     "sr=44100\n",
     "ksmps=32\n",

--- a/python/example2.py
+++ b/python/example2.py
@@ -11,7 +11,7 @@
 
 import csnd6
 
-# Defining our Csound ORC code within a triple-quoted, multline String
+# Defining our Csound ORC code within a triple-quoted, multiline String
 orc = """
 sr=44100
 ksmps=32


### PR DESCRIPTION
…uoted in non-Python examples