### PR TITLE
Don't use comma operator in delete statements.

### DIFF
--- a/cpp/GenerativeScoreExample.cpp
+++ b/cpp/GenerativeScoreExample.cpp
@@ -122,7 +122,8 @@ perfThread->Play();
 while(perfThread->GetStatus() == 0);
 
 //free Csound and thread objects
-delete csound, perfThread;
+delete csound;
+delete perfThread;
 return 0;
 }
 

--- a/cpp/csPerfThreadExample.cpp
+++ b/cpp/csPerfThreadExample.cpp
@@ -57,7 +57,8 @@ perfThread->Play();
 while(perfThread->GetStatus() == 0);
                        	
 //free Csound and thread objects
-delete csound, perfThread;
+delete csound;
+delete perfThread;
 
 return 0;
 }


### PR DESCRIPTION
The statement
  delete x, y;
does not delete both x and y because
  x, y
is treated as the comma operator by c++.