### PR TITLE
Rust version of the csound's official api examples, demostrating the …

### DIFF
--- a/rust/README.md
+++ b/rust/README.md
@@ -1,0 +1,16 @@
+# Csound 6 - Rust API Examples
+Author: Natanael Mojica <neithanmo@gmail.com>
+2018.01.31
+
+This folder contains examples for using the Csound API in Rust. They start with a minimal usage of Csound and each example afterwards builds upon the previous one.
+## Useful Notes
+
+* It is assumed that you have installed Cargo.
+For instructions about How install rust and tools, check the documentation for [How to install](https://www.rust-lang.org/tools/install)
+* To run an example, in a terminal, go to each example directory.
+```
+$ cd rust/example5
+$ cargo build --release
+$ cargo run
+```
+This will build/run the example 5.

--- a/rust/example1/Cargo.toml
+++ b/rust/example1/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.2"
+csound = "*"

--- a/rust/example1/Cargo.toml
+++ b/rust/example1/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example1"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.2"

--- a/rust/example1/src/main.rs
+++ b/rust/example1/src/main.rs
@@ -1,37 +1,21 @@
+use std::env;
 extern crate csound;
 use csound::*;
 
-static CSD: &str = "<CsoundSynthesizer>
-<CsOptions>
--odac
-</CsOptions>
-<CsInstruments>
-sr = 44100
-ksmps = 32
-nchnls = 2
-0dbfs  = 1
-instr 1
-kamp = .6
-kcps = 440
-ifn  = p4
-asig oscil kamp, kcps, ifn
-     outs asig,asig
-endin
-</CsInstruments>
-<CsScore>
-f1 0 16384 10 1
-i 1 0 2 1
-e
-</CsScore>
-</CsoundSynthesizer>";
-
 fn main() {
-    let mut cs = Csound::new();
+    /* Receive a command line argument, which is the path to a csound file*/
+    let args: Vec<String> = env::args().collect();
 
-    let args = ["csound", CSD];
+    if args.len() < 2 {
+        panic!("not enough arguments - please pass the path to a csound file");
+    }
+
+    /* Creates a new csound instance */
+    let cs = Csound::new();
+
+    let args = ["csound", &args[1]];
+
     cs.compile(&args).unwrap();
-
-    cs.start().unwrap();
-
     cs.perform();
+    cs.stop();
 }

--- a/rust/example1/src/main.rs
+++ b/rust/example1/src/main.rs
@@ -1,0 +1,37 @@
+extern crate csound;
+use csound::*;
+
+static CSD: &str = "<CsoundSynthesizer>
+<CsOptions>
+-odac
+</CsOptions>
+<CsInstruments>
+sr = 44100
+ksmps = 32
+nchnls = 2
+0dbfs  = 1
+instr 1
+kamp = .6
+kcps = 440
+ifn  = p4
+asig oscil kamp, kcps, ifn
+     outs asig,asig
+endin
+</CsInstruments>
+<CsScore>
+f1 0 16384 10 1
+i 1 0 2 1
+e
+</CsScore>
+</CsoundSynthesizer>";
+
+fn main() {
+    let mut cs = Csound::new();
+
+    let args = ["csound", CSD];
+    cs.compile(&args).unwrap();
+
+    cs.start().unwrap();
+
+    cs.perform();
+}

--- a/rust/example10/Cargo.toml
+++ b/rust/example10/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example10"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.1"
+rand = "0.6.4"

--- a/rust/example10/Cargo.toml
+++ b/rust/example10/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.1"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example10/src/main.rs
+++ b/rust/example10/src/main.rs
@@ -1,0 +1,160 @@
+ /* Example 10 - More efficient Channel Communications
+ * Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-30
+ * from the original C example by Steven Yi <stevenyi@gmail.com>
+ * 2013.10.28
+ *
+ * This example continues on from Example 9 and introduces a channel_updater
+ * object. The create_channel_updater function will create and store a
+ * MYFLT* that represents a Csound Channel. Additionally, it will store and
+ * call a performance function pointer and store a void* for data to pass to
+ * that performance function.  update_channel() will use the perf_func with the
+ * data pointer to get a new value and set the value within the MYFLT* channel.
+ *
+ * This example continues the illustration of a progression of a project.  Note
+ * that the process has changed a little bit where we now create a number of
+ * ChannelUpdater objects and store them in an array.  The array is then
+ * iterated through for updating the channel with the latest values.  In a
+ * real-world project, this kind of scenario occurs when there are n-number of
+ * items to update channels and one wants to have a flexible number that may
+ * even change dynamically at runtime. For C, one would probably, use
+ * a linked-list or other data structure than an array to represent a dynamic
+ * list of channel_updaters. For this example, an array was deemed sufficient
+ * to illustrate the concept.
+ */
+
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+extern crate csound;
+use csound::{Csound, ControlChannelType, ControlChannelPtr};
+
+extern crate rand;
+
+/* Trait with update/rest functions*/
+pub trait RandomFunc{
+    fn reset(&mut self);
+    fn update(&mut self) -> f64;
+}
+
+#[derive(Default)]
+pub struct RandomLine {
+    dur:i32,
+    end:f64,
+    increment:f64,
+    current_val:f64,
+    base:f64,
+    range:f64,
+}
+
+impl RandomLine{
+    /* Creates a RandomLine and initializes values */
+    fn create(base:f64, range:f64) -> RandomLine{
+        let mut retval = RandomLine::default();
+        retval.base = base;
+        retval.range = range;
+        retval.reset();
+        retval
+    }
+}
+
+impl RandomFunc for RandomLine{
+    /* Resets a RandomLine by calculating new end, dur, and increment values */
+    fn reset(&mut self){
+        self.dur = (rand::random::<i32>() % 256) + 256;
+        self.end = rand::random::<f64>();
+        self.increment = (self.end - self.current_val) / (self.dur as f64);
+    }
+
+    /* Advances state of random line and returns current value */
+    fn update(&mut self) -> f64{
+        let current_value = self.current_val;
+        self.dur -= 1;
+        if self.dur <= 0 {
+            self.reset();
+        }
+        self.current_val += self.increment;
+        self.base + (current_value * self.range)
+    }
+}
+
+pub struct Updater<'a, T> {
+    channel: ControlChannelPtr<'a>,
+    data: T,
+}
+
+impl<'a, T: RandomFunc>  Updater<'a, T>{
+    fn create(csound: &'a Csound, channel_name: &str,data: T) -> Updater<'a, T>{
+        let channel_pointer = create_channel(csound, channel_name);
+        Updater{
+            channel:channel_pointer,
+            data,
+        }
+    }
+
+    fn update(&mut self){
+        let mut value = [0.0;1];
+        value[0] = self.data.update();
+        self.channel.write(&value);
+    }
+}
+
+fn create_channel<'a>(csound: &'a Csound, channel_name: &str) -> ControlChannelPtr<'a> {
+    match csound.get_channel_ptr(channel_name,
+        ControlChannelType::CSOUND_CONTROL_CHANNEL | ControlChannelType::CSOUND_INPUT_CHANNEL){
+            Ok(ptr)      => ptr,
+            Err(status)  => panic!("Channel not exists {:?}", status),
+        }
+}
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  kamp chnget \"amp\"
+  kfreq chnget \"freq\"
+  printk 0.5, kamp
+  printk 0.5, kfreq
+  aout vco2 kamp, kfreq
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score("i1 0 60").unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create an array with two Channel Updaters */
+    let mut updaters = [Updater::<RandomLine>::create(&cs, "amp", RandomLine::create(0.4, 0.2)),
+                                Updater::<RandomLine>::create(&cs, "freq", RandomLine::create(400.0, 80.0))];
+
+    /* Initialize channel values before running Csound */
+    for updater in updaters.iter_mut(){
+        updater.update();
+    }
+     /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.
+     */
+    while !cs.perform_ksmps() {
+        /* Update Channel Values */
+        for updater in updaters.iter_mut(){
+            //update_channel(updater);
+            updater.update();
+        }
+    }
+    cs.stop();
+}

--- a/rust/example2/Cargo.toml
+++ b/rust/example2/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.2"
+csound = "*"

--- a/rust/example2/Cargo.toml
+++ b/rust/example2/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example2"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.2"

--- a/rust/example2/src/main.rs
+++ b/rust/example2/src/main.rs
@@ -1,0 +1,52 @@
+/* Example 2 - Compilation with Csound without CSD
+* Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-20
+* from the original C example by Steven Yi <stevenyi@gmail.com>
+* 2013.10.28
+ *
+ * In this example, we move from using an external CSD file to
+ * embedding our Csound ORC and SCO code within our Python project.
+ * Besides allowing encapsulating the code within the same file,
+ * using the compile_orc() and read_score() API calls is useful when
+ * the SCO or ORC are generated, or perhaps coming from another
+ * source, such as from a database or network.
+ */
+
+extern crate csound;
+use csound::*;
+
+/* Defining our Csound ORC code within a multiline String */
+static orc: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  aout vco2 0.5, 440
+  outs aout, aout
+endin";
+
+/*Defining our Csound SCO code */
+static sco: &str = "i1 0 1";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac");
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(orc).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score(sco).unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Run Csound to completion */
+    cs.perform();
+
+    cs.stop();
+}

--- a/rust/example3/Cargo.toml
+++ b/rust/example3/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.2"
+csound = "*"

--- a/rust/example3/Cargo.toml
+++ b/rust/example3/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example3"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.2"

--- a/rust/example3/src/main.rs
+++ b/rust/example3/src/main.rs
@@ -1,0 +1,55 @@
+/* Example 3 - Using our own performance loop
+* Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-21
+* from the original C example by Steven Yi <stevenyi@gmail.com>
+* 2013.10.28
+ *
+ * In this example, we use a while loop to perform Csound one audio block at a time.
+ * This technique is important to know as it will allow us to do further processing
+ * safely at block boundaries.  We will explore the technique further in later examples.
+ */
+
+extern crate csound;
+use csound::*;
+
+/* Defining our Csound ORC code within a multiline String */
+static orc: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  aout vco2 0.5, 440
+  outs aout, aout
+endin";
+
+/*Defining our Csound SCO code */
+static sco: &str = "i1 0 1";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using set_option() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac");
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(orc).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score(sco).unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns 0,
+     * which signifies to keep processing.  We will explore this loop
+     * technique in further examples.
+     */
+     while cs.perform_ksmps() == false {
+        /* pass for now */
+     };
+
+    cs.stop();
+}

--- a/rust/example4/Cargo.toml
+++ b/rust/example4/Cargo.toml
@@ -5,4 +5,4 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.2"
+csound = "*"

--- a/rust/example4/Cargo.toml
+++ b/rust/example4/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "example4"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.2"

--- a/rust/example4/src/main.rs
+++ b/rust/example4/src/main.rs
@@ -1,0 +1,64 @@
+/* Example 4 - Using Threads
+* Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-21
+* from the original C example by Steven Yi <stevenyi@gmail.com>
+* 2013.10.28
+*
+* In this example, we use the Rust's thread API for execution csound performance function
+* in another thread. Even though Csound has many useful thread functions.
+* they are not implemented in this bindings yet,
+* sharing data between threads could be incredibly unsafe, so, we take advantage of Rust
+* Threads API which will help us to avoid data races.
+*
+*/
+
+extern crate csound;
+use csound::*;
+
+use std::thread;
+use std::sync::{Mutex, Arc};
+
+/* Defining our Csound ORC code within a multiline String */
+static orc: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  aout vco2 0.5, 440
+  outs aout, aout
+endin";
+
+/*Defining our Csound SCO code */
+static sco: &str = "i1 0 10";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac");
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(orc).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score(sco).unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create a new thread that will use our performance function and
+     * pass in our CSOUND structure. This call is asynchronous and
+     * will immediately return back here to continue code execution
+     */
+     let cs = Arc::new(Mutex::new(cs));
+     let cs = Arc::clone(&cs);
+
+     let child = thread::spawn( move || {
+         while !cs.lock().unwrap().perform_ksmps() {
+         }
+     });
+
+     child.join().unwrap();
+}

--- a/rust/example5/Cargo.toml
+++ b/rust/example5/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example5"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.2"
+rand = "0.6.4"

--- a/rust/example5/Cargo.toml
+++ b/rust/example5/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.2"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example5/src/main.rs
+++ b/rust/example5/src/main.rs
@@ -1,0 +1,134 @@
+
+/* Example 5 - Generating Score
+* Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-22
+* from the original C example by Steven Yi <stevenyi@gmail.com>
+* 2013.10.28
+ *
+ * In this example, we will look at three techniques for generating our Score.
+ *
+ * The first is one we have already seen, which is to just write out the score
+ * by hand as a String.
+ *
+ * Knowing that we pass strings into Csound to pass note events, we can also
+ * generate the string.  In the second example, generate_sco2 starts with an empty string.
+ * Using a for-loop, we append to retval note strings using a string formatting
+ * string that has its replacement values replaced.  The replace values are
+ * calculated using the i value, and the result is an ascending note line.
+ *
+ * In the final example, we are going to generate a 2-dimensional array.  The top-level
+ * array represents our score as a whole, and each sub-array within it represents
+ * the data for a single note.  The values are populated and then a second step is done
+ * to format the values into a string and to concatenate that value to the retval string.
+ * The end result is a sequence of 13 notes with random pitches.
+ *
+ * The final example represents a common pattern of development.  For systems that
+ * employ some event-based model of music, it is common to use some kind of data
+ * structure to represent events.  This may use some kind of common data structure
+ * like an array, or it may be represented by using a struct and instances of that
+ * struct.
+ *
+ * Note, the three examples here are indicated with comments.  To listen to the examples,
+ * look for the lines that have read_score() (lines 108-112), uncomment the one
+ * you want to hear, and comment out the others.
+ */
+
+extern crate csound;
+use csound::*;
+use std::fmt::Write;
+
+extern crate rand;
+use rand::Rng;
+
+use std::thread;
+use std::sync::{Mutex, Arc};
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  ipch = cps2pch(p5, 12)
+  kenv linsegr 0, .05, 1, .05, .7, .4, 0
+  aout vco2 p4 * kenv, ipch
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+/* Example 1 - Static Score */
+static SCO:&str = "i1 0 1 0.5 8.00";
+
+fn generate_example2() -> String{
+    let mut retval = String::with_capacity(1024);
+    for i in 0..13{
+        writeln!(&mut retval, "i1 {} .25 .5 8.{:02}", (i as f64)*0.25, i).unwrap();
+    }
+    println!("{}", retval);
+    retval
+}
+
+fn generate_example3() -> String{
+
+    let mut rng = rand::thread_rng();
+
+    let mut retval = String::with_capacity(1024);
+    let mut values = [[0f64; 13]; 5];
+
+    /* Populate array */
+    for i in 0..13{
+        values[0][i] = 1f64;
+        values[1][i] = i as f64 * 0.25;
+        values[2][i] = 0.25;
+        values[3][i] = 0.5;
+        values[4][i] = rng.gen_range(0.0, 15.0);
+    }
+
+    /* Convert array to to String */
+    for i in 0..13{
+        writeln!(&mut retval, "i{} {} {}  {} 8.{:02}",
+                    values[0][i] as u32, values[1][i], values[2][i], values[3][i], values[4][i] as u32).unwrap();
+    }
+    println!("{}", retval);
+    retval
+}
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+
+    //cs.read_score(&generate_example2()).unwrap();
+
+    //cs.read_score(SCO).unwrap();
+
+    cs.read_score(&generate_example3()).unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create a new thread that will use our performance function and
+     * pass in our CSOUND structure. This call is asynchronous and
+     * will immediately return back here to continue code execution
+     */
+     let cs = Arc::new(Mutex::new(cs));
+     let cs = Arc::clone(&cs);
+
+    let child = thread::spawn( move || {
+        while !cs.lock().unwrap().perform_ksmps() {
+            /* pass for now */
+        }
+    });
+
+    child.join().unwrap();
+
+
+}

--- a/rust/example6/Cargo.toml
+++ b/rust/example6/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example6"
+version = "0.1.0"
+authors = ["NMojica <nmojica@signalsecure.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.1"
+rand = "0.6.4"

--- a/rust/example6/Cargo.toml
+++ b/rust/example6/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["NMojica <nmojica@signalsecure.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.1"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example6/src/main.rs
+++ b/rust/example6/src/main.rs
@@ -1,0 +1,108 @@
+/* Example 6 - Generating Score
+ * Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-22
+ * from the original C example by Steven Yi <stevenyi@gmail.com>
+ * 2013.10.28
+ *
+ * This example continues on from Example 5, rewriting the example using
+ * a struct called Note. This example also shows how an array of notes
+ * could be used multiple times.  The first loop through we use the notes
+ * as-is, and during the second time we generate the notes again with
+ * the same properties except we alter the fifth p-field up 4 semitones
+ * and offset the start time.
+ */
+
+extern crate csound;
+use csound::*;
+use std::fmt::Write;
+
+extern crate rand;
+use rand::Rng;
+
+#[derive(Default, Debug, Copy, Clone)]
+struct Note{
+    instr_id:u32,
+    start:f64,
+    duration:f64,
+    amplitude:f64,
+    midi_keynum:u32,
+}
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  ipch = cps2pch(p5, 12)
+  kenv linsegr 0, .05, 1, .05, .7, .4, 0
+  aout vco2 p4 * kenv, ipch
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+/* Example 1 - Static Score */
+static SCO:&str = "i1 0 1 0.5 8.00";
+
+fn midi2pch(midi_keynum:u32) -> String{
+    format!("{}.{:02}", (3 + (midi_keynum / 12)), (midi_keynum % 12))
+}
+
+fn generate_score() -> String{
+
+    let mut notes = [Note::default();13];
+    let mut rng = rand::thread_rng();
+    let mut retval = String::with_capacity(1024);
+
+    /* Populate Notes */
+    for (i, note) in notes.iter_mut().enumerate(){
+        note.instr_id = 1;
+        note.start = i as f64 * 0.25;
+        note.duration = 0.25;
+        note.amplitude = 0.5;
+        note.midi_keynum = 60 + rng.gen_range(0, 15);
+
+    }
+
+    /* Convert notes to to String */
+    for note in &notes{
+        writeln!(&mut retval, "i{} {} {}  {} {}",
+                    note.instr_id, note.start, note.duration, note.amplitude, midi2pch(note.midi_keynum)).unwrap();
+    }
+
+    /* Generate notes again transposed a Major 3rd up */
+    for note in &notes{
+        writeln!(&mut retval, "i{} {} {}  {} {}",
+                    note.instr_id, note.start + 0.125, note.duration, note.amplitude, midi2pch(note.midi_keynum + 4)).unwrap();
+    }
+    println!("{}", retval);
+    retval
+}
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score(&generate_score()).unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+     /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.  We will explore this loop
+     * technique in further examples.
+     */
+    while !cs.perform_ksmps() {
+        /* pass for now */
+    }
+    cs.stop();
+}

--- a/rust/example7/Cargo.toml
+++ b/rust/example7/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example7"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.1"
+rand = "0.6.4"

--- a/rust/example7/Cargo.toml
+++ b/rust/example7/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.1"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example7/src/main.rs
+++ b/rust/example7/src/main.rs
@@ -1,0 +1,124 @@
+
+/* Example 7 - Communicating continuous values with Csound's Channel System
+ * Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-24
+ * from the original C example by Steven Yi <stevenyi@gmail.com>
+ * 2013.10.28
+ *
+ * This example introduces using Csound's Channel System to communicate
+ * continuous control data (k-rate) from a host program to Csound. The
+ * first thing to note is random_line_create(). It takes in a base value
+ * and a range in which to vary randomly.  The reset functions calculates
+ * a new random target value (end), a random duration in which to
+ * run (dur, expressed as # of audio blocks to last in duration), and
+ * calculates the increment value to apply to the current value per audio-block.
+ * When the target is met, the random_line_tick() function will call
+ * random_line_reset() to update a new target value and duration.
+ *
+ * In this example, we use two random_line's, one for amplitude and
+ * another for frequency.  We start a Csound instrument instance that reads
+ * from two channels using the chnget opcode. In turn, we update the values
+ * to the channel from the host program. To update the channel,
+ * we call the set_control_channel function on the Csound object, passing
+ * a channel name and value.  Note: The random_line_tick() function not only
+ * gets us the current value, but also advances the internal state by the
+ * increment and by decrementing the duration.
+ */
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+extern crate csound;
+use csound::*;
+
+extern crate rand;
+
+
+#[derive(Default)]
+pub struct random_line {
+    dur:i32,
+    end:f64,
+    increment:f64,
+    current_val:f64,
+    base:f64,
+    range:f64,
+}
+
+/* Resets a random_line by calculating new end, dur, and increment values */
+fn random_line_reset(rline: &mut random_line ){
+    rline.dur = (rand::random::<i32>() % 256) + 256;
+    rline.end = rand::random::<f64>(); // check
+    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
+}
+
+/* Creates a random_line and initializes values */
+pub fn random_line_create(base:f64, range:f64) -> random_line{
+    let mut retval = random_line::default();
+    retval.base = base;
+    retval.range = range;
+    random_line_reset(&mut retval);
+    retval
+}
+
+/* Advances state of random line and returns current value */
+fn random_line_tick(rline: &mut random_line) -> f64 {
+    let current_value = rline.current_val;
+    rline.dur -= 1;
+    if rline.dur <= 0 {
+        random_line_reset(rline);
+    }
+    rline.current_val += rline.increment;
+    rline.base + (current_value * rline.range)
+}
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  kamp chnget \"amp\"
+  kfreq chnget \"freq\"
+  printk 0.5, kamp
+  printk 0.5, kfreq
+  aout vco2 kamp, kfreq
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score("i1 0 60").unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create a random_line for use with Amplitude */
+    let mut amp = random_line_create(0.4, 0.2);
+
+    /* Create a random_line for use with Frequency */
+    let mut freq = random_line_create(400.0, 80.0);
+
+    /* Initialize channel values before running Csound */
+    cs.set_control_channel("amp", random_line_tick(&mut amp));
+    cs.set_control_channel("freq", random_line_tick(&mut freq));
+
+     /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.  We will explore this loop
+     * technique in further examples.
+     */
+    while !cs.perform_ksmps() {
+        /* Update Channel Values */
+        cs.set_control_channel("amp", random_line_tick(&mut amp));
+        cs.set_control_channel("freq", random_line_tick(&mut freq));
+    }
+    cs.stop();
+}

--- a/rust/example8/Cargo.toml
+++ b/rust/example8/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example8"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.1"
+rand = "0.6.4"

--- a/rust/example8/Cargo.toml
+++ b/rust/example8/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.1"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example8/src/main.rs
+++ b/rust/example8/src/main.rs
@@ -1,0 +1,128 @@
+
+/* Example 8 - More efficient Channel Communications
+ * Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-25
+ * from the original C example by Steven Yi <stevenyi@gmail.com>
+ * 2013.10.28
+ *
+ * This example builds on Example 7 by replacing the calls to set_control_channel
+ * with using get_channel_ptr. In the Csound API, using set_control_channel
+ * and get_control_channel is great for quick work, but ultimately it is slower
+ * than pre-fetching the actual channel pointer.  This is because
+ * Set/GetControlChannel operates by doing a lookup of the Channel Pointer,
+ * then setting or getting the value.  This happens on each call. The
+ * alternative is to use get_channel_ptr, which fetches a Channel Pointer object
+ * and lets you directly using the write/read methods of this channel_ptr object
+ *
+ * One thing to note though is that csoundSetControlChannel is protected by
+ * spinlocks.  This means that it is safe for multithreading to use.  However,
+ * if you are working with your own performance-loop, you can correctly process
+ * updates to channels and there will be no problems with multithreading.
+ *
+ */
+
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+extern crate csound;
+use csound::{Csound, ControlChannelType};
+
+extern crate rand;
+
+
+#[derive(Default)]
+pub struct random_line {
+    dur:i32,
+    end:f64,
+    increment:f64,
+    current_val:f64,
+    base:f64,
+    range:f64,
+}
+
+/* Resets a random_line by calculating new end, dur, and increment values */
+fn random_line_reset(rline: &mut random_line ){
+    rline.dur = (rand::random::<i32>() % 256) + 256;
+    rline.end = rand::random::<f64>();
+    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
+}
+
+/* Creates a random_line and initializes values */
+pub fn random_line_create(base:f64, range:f64) -> random_line{
+    let mut retval = random_line::default();
+    retval.base = base;
+    retval.range = range;
+    random_line_reset(&mut retval);
+    retval
+}
+
+/* Advances state of random line and returns current value */
+fn random_line_tick(rline: &mut random_line) -> f64 {
+    let current_value = rline.current_val;
+    rline.dur -= 1;
+    if rline.dur <= 0 {
+        random_line_reset(rline);
+    }
+    rline.current_val += rline.increment;
+    rline.base + (current_value * rline.range)
+}
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  kamp chnget \"amp\"
+  kfreq chnget \"freq\"
+  printk 0.5, kamp
+  printk 0.5, kfreq
+  aout vco2 kamp, kfreq
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score("i1 0 60").unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create a random_line for use with Amplitude */
+    let mut amp = random_line_create(0.4, 0.2);
+
+    /* Create a random_line for use with Frequency */
+    let mut freq = random_line_create(400.0, 80.0);
+
+    /* Retrieve Channel Pointers from Csound */
+    let amp_channel = cs.get_channel_ptr("amp", ControlChannelType::CSOUND_CONTROL_CHANNEL | ControlChannelType::CSOUND_INPUT_CHANNEL).unwrap();
+    let freq_channel = cs.get_channel_ptr("freq", ControlChannelType::CSOUND_CONTROL_CHANNEL | ControlChannelType::CSOUND_INPUT_CHANNEL).unwrap();
+
+    /* Initialize channel values before running Csound */
+    let mut amp_value = [random_line_tick(&mut amp); 1];
+    let mut freq_value = [random_line_tick(&mut freq); 1];
+
+     /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.  We will explore this loop
+     * technique in further examples.
+     */
+    while !cs.perform_ksmps() {
+        /* Update Channel Values into an slice [f64] */
+        amp_value[0] = random_line_tick(&mut amp);
+        freq_value[0] = random_line_tick(&mut freq);
+        /* pass a reference to the generated slice to channel_ptr object */
+        amp_channel.write(&amp_value);
+        freq_channel.write(&freq_value);
+    }
+    cs.stop();
+}

--- a/rust/example9/Cargo.toml
+++ b/rust/example9/Cargo.toml
@@ -5,5 +5,5 @@ authors = ["Natanael Mojica <neithanmo@gmail.com>"]
 edition = "2018"
 
 [dependencies]
-csound = "0.1.1"
+csound = "*"
 rand = "0.6.4"

--- a/rust/example9/Cargo.toml
+++ b/rust/example9/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "example9"
+version = "0.1.0"
+authors = ["Natanael Mojica <neithanmo@gmail.com>"]
+edition = "2018"
+
+[dependencies]
+csound = "0.1.1"
+rand = "0.6.4"

--- a/rust/example9/src/main.rs
+++ b/rust/example9/src/main.rs
@@ -1,0 +1,127 @@
+
+/* Example 9 - More efficient Channel Communications
+ * Adapted for Rust by Natanael Mojica <neithanmo@gmail.com>, 2019-01-28
+ * from the original C example by Steven Yi <stevenyi@gmail.com>
+ * 2013.10.28
+ *
+ * This example continues on from Example 8 and just refactors the
+ * creation and setup of Csound Channels into a create_channel()
+ * function.  This example illustrates some natural progression that
+ * might occur in your own API-based projects, and how you might
+ * simplify your own code.
+ *
+ */
+
+#![allow(non_camel_case_types, non_upper_case_globals, non_snake_case)]
+extern crate csound;
+use csound::{Csound, ControlChannelType, ControlChannelPtr};
+
+extern crate rand;
+
+
+#[derive(Default)]
+pub struct RandomLine {
+    dur:i32,
+    end:f64,
+    increment:f64,
+    current_val:f64,
+    base:f64,
+    range:f64,
+}
+
+/* Resets a RandomLine by calculating new end, dur, and increment values */
+fn random_line_reset(rline: &mut RandomLine ){
+    rline.dur = (rand::random::<i32>() % 256) + 256;
+    rline.end = rand::random::<f64>();
+    rline.increment = (rline.end - rline.current_val) / (rline.dur as f64);
+}
+
+/* Creates a RandomLine and initializes values */
+pub fn random_line_create(base:f64, range:f64) -> RandomLine{
+    let mut retval = RandomLine::default();
+    retval.base = base;
+    retval.range = range;
+    random_line_reset(&mut retval);
+    retval
+}
+
+/* Advances state of random line and returns current value */
+fn random_line_tick(rline: &mut RandomLine) -> f64 {
+    let current_value = rline.current_val;
+    rline.dur -= 1;
+    if rline.dur <= 0 {
+        random_line_reset(rline);
+    }
+    rline.current_val += rline.increment;
+    rline.base + (current_value * rline.range)
+}
+
+fn create_channel<'a>(csound: &'a Csound, channel_name: &str) -> ControlChannelPtr<'a> {
+    match csound.get_channel_ptr(channel_name,
+        ControlChannelType::CSOUND_CONTROL_CHANNEL | ControlChannelType::CSOUND_INPUT_CHANNEL){
+            Ok(ptr)      => ptr,
+            Err(status)  => panic!("Channel not exists {:?}", status),
+        }
+}
+
+/* Defining our Csound ORC code within a multiline String */
+static ORC: &str = "sr=44100
+  ksmps=32
+  nchnls=2
+  0dbfs=1
+  instr 1
+  kamp chnget \"amp\"
+  kfreq chnget \"freq\"
+  printk 0.5, kamp
+  printk 0.5, kfreq
+  aout vco2 kamp, kfreq
+  aout moogladder aout, 2000, 0.25
+  outs aout, aout
+endin";
+
+fn main() {
+
+    let mut cs = Csound::new();
+
+    /* Using SetOption() to configure Csound
+    Note: use only one commandline flag at a time */
+    cs.set_option("-odac").unwrap();
+
+    /* Compile the Csound Orchestra string */
+    cs.compile_orc(ORC).unwrap();
+
+    /* Compile the Csound SCO String */
+    cs.read_score("i1 0 60").unwrap();
+
+    /* When compiling from strings, this call is necessary
+     * before doing any performing */
+    cs.start().unwrap();
+
+    /* Create a RandomLine for use with Amplitude */
+    let mut amp = random_line_create(0.4, 0.2);
+
+    /* Create a RandomLine for use with Frequency */
+    let mut freq = random_line_create(400.0, 80.0);
+
+    /* Retrieve Channel Pointers from Csound */
+    let amp_channel = create_channel(&cs, "amp");
+    let freq_channel = create_channel(&cs, "freq");
+
+    /* Initialize channel values before running Csound */
+    let mut amp_value = [random_line_tick(&mut amp); 1];
+    let mut freq_value = [random_line_tick(&mut freq); 1];
+
+     /* The following is our main performance loop. We will perform one
+     * block of sound at a time and continue to do so while it returns false,
+     * which signifies to keep processing.  We will explore this loop
+     * technique in further examples.
+     */
+    while !cs.perform_ksmps() {
+        /* Update Channel Values */
+        amp_value[0] = random_line_tick(&mut amp);
+        freq_value[0] = random_line_tick(&mut freq);
+        amp_channel.write(&amp_value);
+        freq_channel.write(&freq_value);
+    }
+    cs.stop();
+}


### PR DESCRIPTION
…new csound's bindings for rust
The Rust bindings could be found here: https://crates.io/crates/csound 
or https://github.com/neithanmo/csound-rs
The bindings documentation could be generated through cargo doc by cloning the repository, and then call inside of the repository directory:
                 cargo doc --open.
This bindings are almost finished, and has been tested on linux.
I have to fix the build.rs script in order to be able to link to the csound libraries on windows and Mac.